### PR TITLE
Delete migration directory

### DIFF
--- a/migration/migrations.yml
+++ b/migration/migrations.yml
@@ -1,4 +1,0 @@
-name: mollie module migration
-migrations_namespace: Mollie\Payment\Migrations
-table_name: oxmigrations_mollie
-migrations_directory: data


### PR DESCRIPTION
We removed the migration directory since there is no migration in the mollie module and migrations stop working in OX 7.1 if this file is abundant.

Please review if you merge this. Thank you!