### PR TITLE
PIOXD-414 Add Wero payment method

### DIFF
--- a/Application/Helper/Payment.php
+++ b/Application/Helper/Payment.php
@@ -64,6 +64,7 @@ class Payment
         'molliepaybybank'       => array('title' => 'Pay by Bank',         'model' => \Mollie\Payment\Application\Model\Payment\PayByBank::class),
         'molliesatispay'        => array('title' => 'Satispay',            'model' => \Mollie\Payment\Application\Model\Payment\Satispay::class),
         'mollieswish'           => array('title' => 'Swish',               'model' => \Mollie\Payment\Application\Model\Payment\Swish::class),
+        'molliewero'            => array('title' => 'Wero',                'model' => \Mollie\Payment\Application\Model\Payment\Wero::class),
     );
 
     /**

--- a/Application/Model/Payment/Wero.php
+++ b/Application/Model/Payment/Wero.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Mollie\Payment\Application\Model\Payment;
+
+class Wero extends Base
+{
+    /**
+     * Payment id in the oxid shop
+     *
+     * @var string
+     */
+    protected $sOxidPaymentId = 'molliewero';
+
+    /**
+     * Method code used for API request
+     *
+     * @var string
+     */
+    protected $sMolliePaymentCode = 'wero';
+
+    /**
+     * If filled, the payment method will only be shown if one of the allowed currencies is active in checkout
+     *
+     * @var array
+     */
+    protected $aAllowedCurrencies = [
+        'EUR',
+    ];
+
+    /**
+     * Array with country-codes the payment method is restricted to
+     * If property is set to false it is available to all countries
+     *
+     * @var array|false
+     */
+    protected $aBillingCountryRestrictedTo = [
+        'DE', 'BE', 'FR', 'LU',
+    ];
+
+    /**
+     * Is used to show in backend if payment method can be used in general
+     * This method has the purpose to be overloaded by child-classes with specific parameters
+     *
+     * @return bool
+     */
+    public function isMolliePaymentActiveInGeneral()
+    {
+        return $this->isMolliePaymentActive(false, 5, 'EUR');
+    }
+}

--- a/Tests/Unit/Application/Model/Payment/WeroTest.php
+++ b/Tests/Unit/Application/Model/Payment/WeroTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace Mollie\Payment\Tests\Unit\Application\Model\Payment;
+
+use Mollie\Api\Endpoints\MethodEndpoint;
+use Mollie\Payment\Application\Helper\Payment;
+use Mollie\Payment\Application\Model\Payment\Wero;
+use Mollie\Payment\Tests\Unit\ConfigUnitTestCase;
+use OxidEsales\Eshop\Core\UtilsObject;
+
+class WeroTest extends ConfigUnitTestCase
+{
+    public function testGetOxidPaymentId()
+    {
+        $oPayment = new Wero();
+        $this->assertEquals('molliewero', $oPayment->getOxidPaymentId());
+    }
+
+    public function testGetMolliePaymentCode()
+    {
+        $oPayment = new Wero();
+        $this->assertEquals('wero', $oPayment->getMolliePaymentCode());
+    }
+
+    public function testAllowedCurrenciesContainsEur()
+    {
+        $oPayment = new Wero();
+        $this->assertTrue($oPayment->isCurrencySupported('EUR'));
+    }
+
+    public function testNonEurCurrencyNotSupported()
+    {
+        $oPayment = new Wero();
+        $this->assertFalse($oPayment->isCurrencySupported('CHF'));
+    }
+
+    public function testCountryRestrictionAllowsDE()
+    {
+        $oPayment = new Wero();
+        $this->assertTrue($oPayment->mollieIsMethodAvailableForCountry('DE'));
+    }
+
+    public function testCountryRestrictionAllowsBE()
+    {
+        $oPayment = new Wero();
+        $this->assertTrue($oPayment->mollieIsMethodAvailableForCountry('BE'));
+    }
+
+    public function testCountryRestrictionAllowsFR()
+    {
+        $oPayment = new Wero();
+        $this->assertTrue($oPayment->mollieIsMethodAvailableForCountry('FR'));
+    }
+
+    public function testCountryRestrictionAllowsLU()
+    {
+        $oPayment = new Wero();
+        $this->assertTrue($oPayment->mollieIsMethodAvailableForCountry('LU'));
+    }
+
+    public function testCountryRestrictionBlocksOtherCountry()
+    {
+        $oPayment = new Wero();
+        $this->assertFalse($oPayment->mollieIsMethodAvailableForCountry('US'));
+    }
+
+    public function testIsMolliePaymentActiveInGeneralReturnsFalseWhenNotActive()
+    {
+        $oMethods = $this->getMockBuilder(MethodEndpoint::class)->disableOriginalConstructor()->getMock();
+        $oMethods->method('all')->willReturn([]);
+
+        $oMollieApi = $this->getMockBuilder(\Mollie\Api\MollieApiClient::class)->disableOriginalConstructor()->getMock();
+        $oMollieApi->methods = $oMethods;
+
+        UtilsObject::setClassInstance(\Mollie\Api\MollieApiClient::class, $oMollieApi);
+
+        $oPayment = new Wero();
+        $this->assertFalse($oPayment->isMolliePaymentActiveInGeneral());
+
+        Payment::destroyInstance();
+    }
+
+    public function testIsMolliePaymentActiveInGeneralReturnsTrueWhenActive()
+    {
+        $oImage = new \stdClass();
+        $oImage->size2x = 'img.png';
+
+        $oItem = $this->getMockBuilder(\Mollie\Api\Resources\Method::class)->disableOriginalConstructor()->getMock();
+        $oItem->id = 'wero';
+        $oItem->description = 'Wero';
+        $oItem->image = $oImage;
+
+        $oMethods = $this->getMockBuilder(MethodEndpoint::class)->disableOriginalConstructor()->getMock();
+        $oMethods->method('all')->willReturn([$oItem]);
+
+        $oMollieApi = $this->getMockBuilder(\Mollie\Api\MollieApiClient::class)->disableOriginalConstructor()->getMock();
+        $oMollieApi->methods = $oMethods;
+
+        UtilsObject::setClassInstance(\Mollie\Api\MollieApiClient::class, $oMollieApi);
+
+        $oPayment = new Wero();
+        $this->assertTrue($oPayment->isMolliePaymentActiveInGeneral());
+
+        Payment::destroyInstance();
+    }
+
+    public function testIsRegisteredInPaymentHelper()
+    {
+        $aMethods = Payment::getInstance()->getMolliePaymentMethods();
+        $this->assertArrayHasKey('molliewero', $aMethods);
+        $this->assertEquals('Wero', $aMethods['molliewero']);
+
+        Payment::destroyInstance();
+    }
+}


### PR DESCRIPTION
Wero is a wallet/A2A payment method available in DE, BE, FR, LU. EUR-only, uses the Payments API.